### PR TITLE
Enable cors on api

### DIFF
--- a/src/FourthDown.Api/Startup.cs
+++ b/src/FourthDown.Api/Startup.cs
@@ -84,6 +84,8 @@ namespace FourthDown.Api
             services.AddOpenTracing();
             services.AddResponseCaching();
 
+            services.AddCors();
+
             services.AddLogging(config =>
             {
                 config.AddDebug();
@@ -158,6 +160,8 @@ namespace FourthDown.Api
                 app.UseExceptionHandler("/Error");
                 app.UseHsts();
             }
+
+            app.UseCors(builder => builder.WithOrigins("http://localhost:3000"));
 
             app.UseSwagger();
             app.UseRouting();


### PR DESCRIPTION
Should enable cross origin requests. Can configure the cors middleware to only be allowed on specific requests and origins.